### PR TITLE
Revue du routage de dév

### DIFF
--- a/devel.php
+++ b/devel.php
@@ -1,35 +1,51 @@
 <?php
+/* Mini serveur de static pour le développement. */
 
-function content_type($uri) {
-  $path = pathinfo($_SERVER['REQUEST_URI']);
-  switch($path['extension']) {
-  case 'css':
-    return 'text/css';
-  case 'png':
-    return 'image/png';
-  case 'jpeg';
-  case 'jpg':
-    return 'image/jpeg';
-  default:
-    return 'text/plain';
-  }
+function content_type($extension) {
+    switch($extension) {
+    case 'ttf':
+        return 'application/x-font-ttf';
+    case 'css':
+        return 'text/css';
+    case 'png':
+        return 'image/png';
+    case 'jpeg';
+    case 'jpg':
+        return 'image/jpeg';
+    case 'js':
+        return 'application/javascript';
+    default:
+        return 'text/plain';
+    }
+}
+
+function try_file($path) {
+    if (!file_exists($path))
+        return false;
+
+    $info = pathinfo($path);
+    $ext = @$info['extension'] ?: null;
+    header('Content-Type: ' . content_type($ext));
+    readfile($path);
+    return true;
 }
 
 // Contournement de bug dans le serveur embarqué de PHP
 $_SERVER['SCRIPT_NAME'] = substr($_SERVER['SCRIPT_FILENAME'], strlen($_SERVER['DOCUMENT_ROOT']));
+$uri = urldecode($_SERVER["REQUEST_URI"]);
 
-// Fichiers /static/
-if (file_exists('./'.$_SERVER['REQUEST_URI'])) return false;
+if (preg_match('/\.(?:css|gif|ico|jpeg|jpg|js|png|ttf)$/', $uri)) {
+    // Fichiers /static/
+    if (try_file('.' . $uri) === true) return true;
 
-// Fichiers /data/
-$root = getenv('STRASS_ROOT') or 'htdocs/';
-if (file_exists($root.$_SERVER['REQUEST_URI'])) {
-  header('Content-Type: '.content_type($_SERVER['REQUEST_URI']));
-  readfile($root.$_SERVER['REQUEST_URI']);
-  return;
+    // Fichiers /data/
+    $root = getenv('STRASS_ROOT') or 'htdocs';
+    if (try_file($root . $uri) === true) return true;
+
+    header("HTTP/1.0 404 Not Found");
+    error_log("Pas trouvé : " . $path);
+    return true;
 }
 
-if (strpos($_SERVER['REQUEST_URI'], 'favicon.ico')) return false;
-
-// Le reste
-include_once 'index.php';
+/* Passer la main à index.php. */
+return false;

--- a/include/Strass.php
+++ b/include/Strass.php
@@ -49,12 +49,8 @@ class Strass {
         }
 
         require_once 'Wtk.php';
-        require_once 'Zend/Loader/Autoloader.php';
 
-        $loader = Zend_Loader_Autoloader::getInstance();
-        $loader->registerNamespace('Dio_');
-        $loader->registerNamespace('Wtk_');
-        $loader->registerNamespace('Strass_');
+        Wtk::init();
 
         Wtk_Document_Style::$path = array(
             Strass::getPrefix() . 'static/styles/',

--- a/include/Strass/Statique.php
+++ b/include/Strass/Statique.php
@@ -45,7 +45,8 @@ class Statique implements Zend_Acl_Resource_Interface
 
     function read()
     {
-        return @file_get_contents($this->getFilename());
+        if ($this->readable())
+            return @file_get_contents($this->getFilename());
     }
 
     function write($contents)

--- a/include/Strass/Statique.php
+++ b/include/Strass/Statique.php
@@ -5,56 +5,56 @@ require_once 'Wtk.php';
 
 class Statique implements Zend_Acl_Resource_Interface
 {
-  protected $id;
-  protected $title;
+    protected $id;
+    protected $title;
 
 
-  function __construct($id)
-  {
-    $this->id = $id;
-    $this->path = 'private/statiques/'.$id.'.wiki';
-    Zend_Registry::get('acl')->add($this);
+    function __construct($id)
+    {
+        $this->id = $id;
+        $this->path = 'private/statiques/'.$id.'.wiki';
+        Zend_Registry::get('acl')->add($this);
 
-    $this->title = preg_match("`^\+\+ (.*)$`m", $this->read(), $res) ? $res[1] : wtk_ucfirst($this->id);
-  }
+        $this->title = preg_match("`^\+\+ (.*)$`m", $this->read(), $res) ? $res[1] : wtk_ucfirst($this->id);
+    }
 
-  function getId()
-  {
-    return $this->id;
-  }
+    function getId()
+    {
+        return $this->id;
+    }
 
-  function getFilename()
-  {
-    return $this->path;
-  }
+    function getFilename()
+    {
+        return $this->path;
+    }
 
-  function getResourceId()
-  {
-    return 'page-statique-'.$this->id;
-  }
+    function getResourceId()
+    {
+        return 'page-statique-'.$this->id;
+    }
 
-  function getTitle()
-  {
-    return $this->title;
-  }
+    function getTitle()
+    {
+        return $this->title;
+    }
 
-  function readable()
-  {
-    return is_readable($this->getFilename());
-  }
+    function readable()
+    {
+        return is_readable($this->getFilename());
+    }
 
-  function read()
-  {
-    return @file_get_contents($this->getFilename());
-  }
+    function read()
+    {
+        return @file_get_contents($this->getFilename());
+    }
 
-  function write($contents)
-  {
-    file_put_contents($this->getFilename(), $contents);
-  }
+    function write($contents)
+    {
+        file_put_contents($this->getFilename(), $contents);
+    }
 
-  function delete()
-  {
-    unlink($this->getFilename());
-  }
+    function delete()
+    {
+        unlink($this->getFilename());
+    }
 }

--- a/include/Wtk.php
+++ b/include/Wtk.php
@@ -1,6 +1,10 @@
 <?php
 require_once 'Wtk/Utils.php';
 
+/* C'est sale, car Wtk ne cherche que dans son dossier include. En même temps
+ * voilà quoi. */
+define('WTK_INCLUDE_DIR', dirname(__FILE__));
+
 abstract class Wtk
 {
 	public static function init()
@@ -13,7 +17,8 @@ abstract class Wtk
 		$file = str_replace ('_', '/', $class).'.php';
 		$exists = false;
 
-		if (file_exists('include/'.$file))
+
+		if (file_exists(WTK_INCLUDE_DIR . DIRECTORY_SEPARATOR . $file))
 			include_once $file;
 	}
 }

--- a/include/Wtk.php
+++ b/include/Wtk.php
@@ -15,8 +15,6 @@ abstract class Wtk
 	public static function autoload ($class)
 	{
 		$file = str_replace ('_', '/', $class).'.php';
-		$exists = false;
-
 
 		if (file_exists(WTK_INCLUDE_DIR . DIRECTORY_SEPARATOR . $file))
 			include_once $file;


### PR DESCRIPTION
C'est beaucoup plus rapide ainsi, quand on a lu la doc. Les statiques
sont gérée une fois, par le serveur de dév. Les URL en UTF-8 sont
décodée. Le code est dédupliqué. Les logs sont moins verbeux.