### PR TITLE
Virer l'étiquette de l'objet des courriels

### DIFF
--- a/include/Strass/Mail.php
+++ b/include/Strass/Mail.php
@@ -18,9 +18,7 @@ class Strass_Mail extends Zend_Mail
       $metas = new Wtk_Metas($metas);
     }
 
-    $id = $config->get('system/short_title', 'STRASS');
-    $title = "[".$id."] ".$metas->title;
-    $this->setSubject($title);
+    $this->setSubject($metas->title);
 
     $from = getenv('STRASS_EMETTEUR') or '';
     $this->setFrom($from, 'Strass');


### PR DESCRIPTION
C'est buggué et ça fini en []. Et maintenant que l'expéditeur est `Strass`, je préfère bazarder ça.