### PR TITLE
Partager les données avec le groupe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ distclean:
 	$(MAKE) clean
 	rm -rvf $(STRASS_ROOT)
 
+fixperms:
+	chgrp -R $(shell stat -c %G Makefile) $(STRASS_ROOT)
+
 setup:
 	which sqlite3
 	pip install --upgrade libsass

--- a/docker/entrypoint.mk
+++ b/docker/entrypoint.mk
@@ -16,10 +16,8 @@ fcgi: fixperms statics
 
 # S'assurer que le volume est accessible à l'utilisateur strass.
 fixperms:
-	chmod -v 0755 $${STRASS_ROOT}
-	chmod -v 0700 $${STRASS_ROOT}/private ||:
-	chown -v strass: $${STRASS_ROOT} ||:
-	chown -vR strass: $${STRASS_ROOT}/data $${STRASS_ROOT}/private ||:
+	chmod -v o-rwx $${STRASS_ROOT} ||:
+	chown -vR strass $${STRASS_ROOT} ||:
 
 migrate: fixperms
 	$(STRASSDO) scripts/$@


### PR DESCRIPTION
C'est nécessaire pour faire les sauvegardes externe au conteneur. L'idée est que
l'utilisateur propriétaire est un identifiant du conteneur tandis que le groupe
propriétaire est un groupe de l'hôte.

C'est valable également en dév.