### PR TITLE
Wtk et KNACSS, préliminaires

### DIFF
--- a/include/Wtk/Raw.php
+++ b/include/Wtk/Raw.php
@@ -1,0 +1,10 @@
+<?php
+
+class Wtk_Raw extends Wtk_Element
+{
+	function __construct ($raw = '')
+	{
+		parent::__construct ();
+		$this->raw = $raw;
+	}
+}

--- a/include/templates/wtk/document.html.php
+++ b/include/templates/wtk/document.html.php
@@ -1,8 +1,5 @@
 <?php
 
-$creation = $metas->creation;
-$year = date('Y');
-
 $baseurl = '/';
 $dojodbg = 'false';
 

--- a/include/templates/wtk/document.html.php
+++ b/include/templates/wtk/document.html.php
@@ -61,6 +61,15 @@ wtk_attr('href', 'http://'.$_SERVER['HTTP_HOST'].$href);
 <?php endswitch; ?>
 <?php endforeach; ?>
 <?php endforeach; ?>
+  </head>
+<body<?php wtk_classes($flags); ?>>
+<div id="body">
+<?php if (isset($this->header)) $this->header->output(); ?>
+<div id="contentwrapper"><?php if (isset($this->content)) $this->content->output (); ?></div>
+<?php if (isset($this->aside)) $this->aside->output(); ?>
+<?php if (isset($this->footer)) $this->footer->output(); ?>
+<hr id="clearer" style="clear: both; visibility: hidden;" />
+</div>
 
 <?php if (count($dojoTypes)): ?>
 <script language="javascript" type="text/javascript">
@@ -74,14 +83,5 @@ wtk_attr('href', 'http://'.$_SERVER['HTTP_HOST'].$href);
 dojo.require("dojo.parser");
 </script>
 <?php endif; ?>
-  </head>
-<body<?php wtk_classes($flags); ?>>
-<div id="body">
-<?php if (isset($this->header)) $this->header->output(); ?>
-<div id="contentwrapper"><?php if (isset($this->content)) $this->content->output (); ?></div>
-<?php if (isset($this->aside)) $this->aside->output(); ?>
-<?php if (isset($this->footer)) $this->footer->output(); ?>
-<hr id="clearer" style="clear: both; visibility: hidden;" />
-</div>
   </body>
 </html>

--- a/include/templates/wtk/document.html.php
+++ b/include/templates/wtk/document.html.php
@@ -3,8 +3,6 @@
 $creation = $metas->creation;
 $year = date('Y');
 
-$snkp = isset($_SERVER['ORIG_SCRIPT_NAME']) ? 'ORIG_' : '';
-$sn = $_SERVER[$snkp.'SCRIPT_NAME'];
 $baseurl = '/';
 $dojodbg = 'false';
 

--- a/include/templates/wtk/raw.html.php
+++ b/include/templates/wtk/raw.html.php
@@ -1,0 +1,2 @@
+<?php
+echo $raw;

--- a/static/styles/strass/src/common.scss
+++ b/static/styles/strass/src/common.scss
@@ -53,6 +53,10 @@ ul {
     list-style-type: disc;
 }
 
+li {
+  margin-left: 3rem;
+}
+
 #header {
     background-repeat: no-repeat;
     background-position: 96% center;

--- a/static/styles/strass/src/individus.scss
+++ b/static/styles/strass/src/individus.scss
@@ -4,45 +4,47 @@
     white-space: pre-wrap;
 }
 
-#details, #cv {
+.individus {
+  #details, #cv {
     padding: 0 1ex;
     display: inline-block;
     vertical-align: top;
-}
+  }
 
-#details {
+  #details {
     width: 30%;
 
     ul {
-	/* Adapté à la ligne Dernière connexion */
-	min-width: 15em;
-	padding-left: 2em;
+	    /* Adapté à la ligne Dernière connexion */
+	    min-width: 15em;
+	    padding-left: 2em;
     }
 
     #notes {
-	margin: 1ex;
-	font-style: italic;
+	    margin: 1ex;
+	    font-style: italic;
     }
-}
+  }
 
-#cv {
+  #cv {
     width: 69%;
 
     table {
-	width: 100%;
+	    width: 100%;
 
-	thead { display: none; }
-	td.unite {
-	    white-space: nowrap;
-	    width: 80%;
-	}
+	    thead { display: none; }
+	    td.unite {
+	      white-space: nowrap;
+	      width: 80%;
+	    }
     }
-}
+  }
 
-/* si pas de détails */
-#cartevisite + #cv {
+  /* si pas de détails */
+  #cartevisite + #cv {
     display: block;
     margin: 0 auto;
+  }
 }
 
 #document.individus.inscrire .effectifs

--- a/static/styles/strass/src/layout.scss
+++ b/static/styles/strass/src/layout.scss
@@ -563,7 +563,7 @@ div.section.document {
 		    overflow-x: auto;
 
 		    #details {
-			display: block;
+			display: block !important;
 		    }
 		}
 	    }


### PR DESCRIPTION
WTK a été conçu pour **ignorer** la mise-en-page. En la laissant exclusivement au CSS. WTK implémente le patron *Inversion de contrôle*.

Les framework CSS se basent sur les classes CSS, donc la mise-en-page est notée dans le HTML : `class="grid-3"`, etc.

Cela remet complètement en cause WTK. Et en fait, on reviens peu ou prou à ce que ZF fait. Chaque action commence avec une page blanche et est complètement libre de ce qu'il y a dedans.

Je vais remettre en cause, progressivement, l'IoC de WTK pour pouvoir, dans chaques pages, placer le contenu. À suivre.